### PR TITLE
Fix byte-compile warning

### DIFF
--- a/binky-mode.el
+++ b/binky-mode.el
@@ -34,6 +34,7 @@
 
 (require 'cl-lib)
 (require 'cl-extra)
+(require 'subr-x)
 
 ;;; Customize
 


### PR DESCRIPTION
```
binky-mode.el:389:13: Warning: the function ‘string-remove-suffix’ is not
    known to be defined.
```